### PR TITLE
Don't upgrade in builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:latest
 MAINTAINER John Fink <john.fink@gmail.com>
 RUN apt-get update # Mon Jan 27 11:35:22 EST 2014
-RUN apt-get -y upgrade
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 pwgen python-setuptools vim-tiny php5-mysql openssh-server sudo php5-ldap
 RUN easy_install supervisor
 ADD ./start.sh /start.sh


### PR DESCRIPTION
Updates will be baked into the based images you don't need to apt-get upgrade your containers. Because of the isolation that happens this can often fail if something is trying to modify init or make device changes inside a container. It also produces inconsistent images because you no longer have one source of truth of how your application should run and what versions of dependencies are included in the image.
source: http://crosbymichael.com/category/docker.html
