### PR TITLE
Workaround for modifying users under host kernel > 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest
 MAINTAINER John Fink <john.fink@gmail.com>
 RUN apt-get update # Fri Oct 24 13:09:23 EDT 2014
 RUN apt-get -y upgrade
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 pwgen python-setuptools vim-tiny php5-mysql  php5-ldap
+RUN ln -s -f /bin/true /usr/bin/chfn && DEBIAN_FRONTEND=noninteractive apt-get -y install mysql-client mysql-server apache2 libapache2-mod-php5 pwgen python-setuptools vim-tiny php5-mysql  php5-ldap
 RUN easy_install supervisor
 ADD ./scripts/start.sh /start.sh
 ADD ./scripts/foreground.sh /etc/apache2/foreground.sh


### PR DESCRIPTION
Resolves issue where mysql cannot add user in a container if host kernel is version > 3.15 and Docker 1.0.1 (from default ubuntu APT repository)
Find more at https://github.com/docker/docker/issues/6345
